### PR TITLE
add slack integration

### DIFF
--- a/migrations/20240614172639_setup.sql
+++ b/migrations/20240614172639_setup.sql
@@ -31,8 +31,9 @@ CREATE table IF NOT exists scouter.drift_profile (
   version varchar(256),
   profile jsonb,
   active boolean default true,
-  cron  varchar(256),
+  schedule  varchar(256),
   next_run timestamp,
+  previous_run timestamp,
   PRIMARY KEY (name, repository, version)
 );
 

--- a/migrations/20240614172639_setup.sql
+++ b/migrations/20240614172639_setup.sql
@@ -33,7 +33,6 @@ CREATE table IF NOT exists scouter.drift_profile (
   active boolean default true,
   schedule  varchar(256),
   next_run timestamp,
-  previous_run timestamp,
   PRIMARY KEY (name, repository, version)
 );
 

--- a/src/alerts/dispatch.rs
+++ b/src/alerts/dispatch.rs
@@ -260,135 +260,223 @@ impl AlertDispatcher {
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use scouter::utils::types::{Alert, AlertType, AlertZone, FeatureAlert};
-//     use std::collections::HashMap;
-//     use std::env;
-//
-//     fn test_features_hashmap() -> HashMap<String, FeatureAlert> {
-//         let mut features: HashMap<String, FeatureAlert> = HashMap::new();
-//
-//         features.insert(
-//             "test_feature_1".to_string(),
-//             FeatureAlert {
-//                 feature: "test_feature_1".to_string(),
-//                 alerts: vec![Alert {
-//                     zone: AlertZone::OutOfBounds.to_str(),
-//                     kind: AlertType::OutOfBounds.to_str(),
-//                 }],
-//                 indices: Default::default(),
-//             },
-//         );
-//         features.insert(
-//             "test_feature_2".to_string(),
-//             FeatureAlert {
-//                 feature: "test_feature_2".to_string(),
-//                 alerts: vec![Alert {
-//                     zone: AlertZone::Zone1.to_str(),
-//                     kind: AlertType::OutOfBounds.to_str(),
-//                 }],
-//                 indices: Default::default(),
-//             },
-//         );
-//         features
-//     }
-//     #[test]
-//     fn test_construct_opsgenie_alert_description() {
-//         let features = test_features_hashmap();
-//
-//         let alert_description =
-//             OpsGenieAlertDispatcher::construct_alert_description(&FeatureAlerts { features });
-//         let expected_alert_description = "Features that have drifted \ntest_feature_1 alerts: \nalert kind Out of bounds -- alert zone: Out of bounds \ntest_feature_2 alerts: \nalert kind Out of bounds -- alert zone: Zone 1 \n".to_string();
-//         assert_eq!(&alert_description.len(), &expected_alert_description.len());
-//         assert_eq!(
-//             &alert_description.contains(
-//                 "test_feature_1 alerts: \nalert kind Out of bounds -- alert zone: Out of bounds"
-//             ),
-//             &expected_alert_description.contains(
-//                 "test_feature_1 alerts: \nalert kind Out of bounds -- alert zone: Out of bounds"
-//             )
-//         );
-//         assert_eq!(
-//             &alert_description.contains(
-//                 "test_feature_2 alerts: \nalert kind Out of bounds -- alert zone: Zone 1"
-//             ),
-//             &expected_alert_description.contains(
-//                 "test_feature_2 alerts: \nalert kind Out of bounds -- alert zone: Zone 1"
-//             )
-//         );
-//     }
-//
-//     #[test]
-//     fn test_construct_opsgenie_alert_description_empty() {
-//         let features: HashMap<String, FeatureAlert> = HashMap::new();
-//         let alert_description =
-//             OpsGenieAlertDispatcher::construct_alert_description(&FeatureAlerts { features });
-//         let expected_alert_description = "".to_string();
-//         assert_eq!(alert_description, expected_alert_description);
-//     }
-//
-//     #[test]
-//     fn test_construct_opsgenie_alert_body() {
-//         let expected_alert_body = json!(
-//                 {
-//                     "message": "Model drift detected for test_ml_model",
-//                     "description": "Features have drifted",
-//                     "responders":[
-//                         {"name":"ds-team", "type":"team"}
-//                     ],
-//                     "visibleTo":[
-//                         {"name":"ds-team", "type":"team"}
-//                     ],
-//                     "tags": ["Model Drift"],
-//                     "priority": "P1"
-//                 }
-//         );
-//         let alert_body =
-//             OpsGenieAlertDispatcher::construct_alert_body("Features have drifted", "test_ml_model");
-//         assert_eq!(alert_body, expected_alert_body);
-//     }
-//
-//     #[tokio::test]
-//     async fn test_send_opsgenie_alerts() {
-//         let mut download_server = mockito::Server::new_async().await;
-//         let url = download_server.url();
-//
-//         // set env variables
-//         unsafe {
-//             env::set_var("OPSGENIE_API_URL", url);
-//             env::set_var("OPSGENIE_API_KEY", "api_key");
-//         }
-//
-//         let mock_get_path = download_server
-//             .mock("Post", "/alerts")
-//             .with_status(201)
-//             .create();
-//
-//         let features = test_features_hashmap();
-//
-//         let dispatcher = AlertDispatcher::OpsGenie(OpsGenieAlertDispatcher::default());
-//         let _ = dispatcher
-//             .process_alerts(&FeatureAlerts { features }, "test_ml_model")
-//             .await;
-//
-//         mock_get_path.assert();
-//
-//         unsafe {
-//             env::remove_var("OPSGENIE_API_URL");
-//             env::remove_var("OPSGENIE_API_KEY");
-//         }
-//     }
-//
-//     #[tokio::test]
-//     async fn test_send_console_alerts() {
-//         let features = test_features_hashmap();
-//         let dispatcher = AlertDispatcher::Console(ConsoleAlertDispatcher);
-//         let result = dispatcher
-//             .process_alerts(&FeatureAlerts { features }, "test_ml_model")
-//             .await;
-//
-//         assert!(result.is_ok());
-//     }
-// }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scouter::utils::types::{Alert, AlertType, AlertZone, FeatureAlert};
+    use std::collections::HashMap;
+    use std::env;
+
+    fn test_features_hashmap() -> HashMap<String, FeatureAlert> {
+        let mut features: HashMap<String, FeatureAlert> = HashMap::new();
+
+        features.insert(
+            "test_feature_1".to_string(),
+            FeatureAlert {
+                feature: "test_feature_1".to_string(),
+                alerts: vec![Alert {
+                    zone: AlertZone::OutOfBounds.to_str(),
+                    kind: AlertType::OutOfBounds.to_str(),
+                }],
+                indices: Default::default(),
+            },
+        );
+        features.insert(
+            "test_feature_2".to_string(),
+            FeatureAlert {
+                feature: "test_feature_2".to_string(),
+                alerts: vec![Alert {
+                    zone: AlertZone::Zone1.to_str(),
+                    kind: AlertType::OutOfBounds.to_str(),
+                }],
+                indices: Default::default(),
+            },
+        );
+        features
+    }
+    #[test]
+    fn test_construct_opsgenie_alert_description() {
+        let features = test_features_hashmap();
+        let alerter = OpsGenieAlerter::default();
+        let alert_description = alerter.construct_alert_description(&FeatureAlerts { features });
+        let expected_alert_description = "Features that have drifted \ntest_feature_1 alerts: \nalert kind Out of bounds -- alert zone: Out of bounds \ntest_feature_2 alerts: \nalert kind Out of bounds -- alert zone: Zone 1 \n".to_string();
+        assert_eq!(&alert_description.len(), &expected_alert_description.len());
+        assert_eq!(
+            &alert_description.contains(
+                "test_feature_1 alerts: \nalert kind Out of bounds -- alert zone: Out of bounds"
+            ),
+            &expected_alert_description.contains(
+                "test_feature_1 alerts: \nalert kind Out of bounds -- alert zone: Out of bounds"
+            )
+        );
+        assert_eq!(
+            &alert_description.contains(
+                "test_feature_2 alerts: \nalert kind Out of bounds -- alert zone: Zone 1"
+            ),
+            &expected_alert_description.contains(
+                "test_feature_2 alerts: \nalert kind Out of bounds -- alert zone: Zone 1"
+            )
+        );
+    }
+
+    #[test]
+    fn test_construct_opsgenie_alert_description_empty() {
+        let features: HashMap<String, FeatureAlert> = HashMap::new();
+        let alerter = OpsGenieAlerter::default();
+        let alert_description = alerter.construct_alert_description(&FeatureAlerts { features });
+        let expected_alert_description = "".to_string();
+        assert_eq!(alert_description, expected_alert_description);
+    }
+
+    #[tokio::test]
+    async fn test_construct_opsgenie_alert_body() {
+        // set env variables
+        let download_server = mockito::Server::new_async().await;
+        let url = download_server.url();
+
+        // set env variables
+        unsafe {
+            env::set_var("OPSGENIE_API_URL", url);
+            env::set_var("OPSGENIE_API_KEY", "api_key");
+        }
+        let expected_alert_body = json!(
+                {
+                    "message": "Model drift detected for test_ml_model",
+                    "description": "Features have drifted",
+                    "responders":[
+                        {"name":"ds-team", "type":"team"}
+                    ],
+                    "visibleTo":[
+                        {"name":"ds-team", "type":"team"}
+                    ],
+                    "tags": ["Model Drift"],
+                    "priority": "P1"
+                }
+        );
+        let alerter = OpsGenieAlerter::default();
+        let alert_body = alerter.construct_alert_body("Features have drifted", "test_ml_model");
+        assert_eq!(alert_body, expected_alert_body);
+        unsafe {
+            env::remove_var("OPSGENIE_API_URL");
+            env::remove_var("OPSGENIE_API_KEY");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_opsgenie_alerts() {
+        let mut download_server = mockito::Server::new_async().await;
+        let url = download_server.url();
+
+        // set env variables
+        unsafe {
+            env::set_var("OPSGENIE_API_URL", url);
+            env::set_var("OPSGENIE_API_KEY", "api_key");
+        }
+
+        let mock_get_path = download_server
+            .mock("Post", "/alerts")
+            .with_status(201)
+            .create();
+
+        let features = test_features_hashmap();
+
+        let dispatcher =
+            AlertDispatcher::OpsGenie(HttpAlertDispatcher::new(OpsGenieAlerter::default()));
+        let _ = dispatcher
+            .process_alerts(&FeatureAlerts { features }, "test_ml_model")
+            .await;
+
+        mock_get_path.assert();
+
+        unsafe {
+            env::remove_var("OPSGENIE_API_URL");
+            env::remove_var("OPSGENIE_API_KEY");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_console_alerts() {
+        let features = test_features_hashmap();
+        let dispatcher = AlertDispatcher::Console(ConsoleAlertDispatcher);
+        let result = dispatcher
+            .process_alerts(&FeatureAlerts { features }, "test_ml_model")
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_send_slack_alerts() {
+        let mut download_server = mockito::Server::new_async().await;
+        let url = download_server.url();
+
+        // set env variables
+        unsafe {
+            env::set_var("SLACK_API_URL", url);
+            env::set_var("SLACK_BOT_TOKEN", "bot_token");
+        }
+
+        let mock_get_path = download_server
+            .mock("Post", "/chat.postMessage")
+            .with_status(201)
+            .create();
+
+        let features = test_features_hashmap();
+
+        let dispatcher = AlertDispatcher::Slack(HttpAlertDispatcher::new(SlackAlerter::default()));
+        let _ = dispatcher
+            .process_alerts(&FeatureAlerts { features }, "test_ml_model")
+            .await;
+
+        mock_get_path.assert();
+
+        unsafe {
+            env::remove_var("SLACK_API_URL");
+            env::remove_var("SLACK_BOT_TOKEN");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_construct_slack_alert_body() {
+        // set env variables
+        let download_server = mockito::Server::new_async().await;
+        let url = download_server.url();
+
+        unsafe {
+            env::set_var("SLACK_API_URL", url);
+            env::set_var("SLACK_BOT_TOKEN", "bot_token");
+        }
+        let expected_alert_body = json!({
+            "channel": "bot-test",
+            "blocks": [
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": ":red_circle: Model drift detected for test_ml_model :red_circle:",
+                        "emoji": true
+                    }
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "*Features have drifted*"
+                    },
+                    "accessory": {
+                        "type": "image",
+                        "image_url": "https://www.shutterstock.com/shutterstock/photos/2196561307/display_1500/stock-vector--d-vector-yellow-warning-sign-with-exclamation-mark-concept-eps-vector-2196561307.jpg",
+                        "alt_text": "Alert Symbol"
+                    }
+                }
+            ]
+        });
+        let alerter = SlackAlerter::default();
+        let alert_body = alerter.construct_alert_body("*Features have drifted*", "test_ml_model");
+        assert_eq!(alert_body, expected_alert_body);
+        unsafe {
+            env::remove_var("SLACK_API_URL");
+            env::remove_var("SLACK_BOT_TOKEN");
+        }
+    }
+}

--- a/src/alerts/dispatch.rs
+++ b/src/alerts/dispatch.rs
@@ -68,7 +68,7 @@ impl HttpAlertWrapper for OpsGenieAlerter {
         &self.header_auth_value
     }
 
-    fn construct_alert_body(&self, alert_description: &str, name: &str, repository: &str) -> Value {
+    fn construct_alert_body(&self, alert_description: &str, repository: &str, name: &str) -> Value {
         json!(
                 {
                     "message": format!("Model drift detected for {}/{}", repository, name),
@@ -116,7 +116,7 @@ impl HttpAlertWrapper for SlackAlerter {
         &self.header_auth_value
     }
 
-    fn construct_alert_body(&self, alert_description: &str, name: &str, repository: &str) -> Value {
+    fn construct_alert_body(&self, alert_description: &str, repository: &str, name: &str) -> Value {
         json!({
             "channel": "bot-test",
             "blocks": [
@@ -345,7 +345,7 @@ mod tests {
         }
         let expected_alert_body = json!(
                 {
-                    "message": "Model drift detected for test_ml_model",
+                    "message": "Model drift detected for test_repo/test_ml_model",
                     "description": "Features have drifted",
                     "responders":[
                         {"name":"ds-team", "type":"team"}

--- a/src/alerts/dispatch.rs
+++ b/src/alerts/dispatch.rs
@@ -232,8 +232,8 @@ impl DispatchHelpers for ConsoleAlertDispatcher {}
 #[derive(Debug)]
 pub enum AlertDispatcher {
     Console(ConsoleAlertDispatcher),
-    OpsGenieAlertDispatcher(HttpAlertDispatcher<OpsGenieAlerter>),
-    SlackAlertDispatcher(HttpAlertDispatcher<SlackAlerter>),
+    OpsGenie(HttpAlertDispatcher<OpsGenieAlerter>),
+    Slack(HttpAlertDispatcher<SlackAlerter>),
 }
 
 impl AlertDispatcher {
@@ -248,11 +248,11 @@ impl AlertDispatcher {
                 .process_alerts(feature_alerts, service_name)
                 .await
                 .with_context(|| "Error processing alerts"),
-            AlertDispatcher::OpsGenieAlertDispatcher(dispatcher) => dispatcher
+            AlertDispatcher::OpsGenie(dispatcher) => dispatcher
                 .process_alerts(feature_alerts, service_name)
                 .await
                 .with_context(|| "Error processing alerts"),
-            AlertDispatcher::SlackAlertDispatcher(dispatcher) => dispatcher
+            AlertDispatcher::Slack(dispatcher) => dispatcher
                 .process_alerts(feature_alerts, service_name)
                 .await
                 .with_context(|| "Error processing alerts"),

--- a/src/alerts/drift.rs
+++ b/src/alerts/drift.rs
@@ -7,12 +7,13 @@ use scouter::utils::types::{AlertDispatchType, DriftProfile};
 
 use anyhow::{Context, Result};
 
-use crate::alerts::dispatch::{AlertDispatcher, ConsoleAlertDispatcher, OpsGenieAlertDispatcher, SlackAlertDispatcher};
+use crate::alerts::dispatch::{
+    AlertDispatcher, ConsoleAlertDispatcher, HttpAlertDispatcher, OpsGenieAlerter, SlackAlerter,
+};
 use ndarray::Array2;
 use sqlx::{Postgres, Row};
 use tracing::info;
 
-#[derive(Debug)]
 pub struct DriftExecutor {
     db_client: PostgresClient,
     alert_dispatcher: AlertDispatcher,
@@ -77,10 +78,12 @@ impl DriftExecutor {
     fn map_dispatcher(dispatch_type: &AlertDispatchType) -> AlertDispatcher {
         match dispatch_type {
             AlertDispatchType::Console => AlertDispatcher::Console(ConsoleAlertDispatcher),
-            AlertDispatchType::OpsGenie => {
-                AlertDispatcher::OpsGenie(OpsGenieAlertDispatcher::default())
-            }
-            AlertDispatchType::Slack => AlertDispatcher::Slack(SlackAlertDispatcher::default()),
+            AlertDispatchType::OpsGenie => AlertDispatcher::OpsGenieAlertDispatcher(
+                HttpAlertDispatcher::new(OpsGenieAlerter::default()),
+            ),
+            AlertDispatchType::Slack => AlertDispatcher::SlackAlertDispatcher(
+                HttpAlertDispatcher::new(SlackAlerter::default()),
+            ),
             AlertDispatchType::Email => panic!("Unsupported dispatcher type: Email"),
         }
     }

--- a/src/alerts/drift.rs
+++ b/src/alerts/drift.rs
@@ -78,10 +78,10 @@ impl DriftExecutor {
     fn map_dispatcher(dispatch_type: &AlertDispatchType) -> AlertDispatcher {
         match dispatch_type {
             AlertDispatchType::Console => AlertDispatcher::Console(ConsoleAlertDispatcher),
-            AlertDispatchType::OpsGenie => AlertDispatcher::OpsGenieAlertDispatcher(
+            AlertDispatchType::OpsGenie => AlertDispatcher::OpsGenie(
                 HttpAlertDispatcher::new(OpsGenieAlerter::default()),
             ),
-            AlertDispatchType::Slack => AlertDispatcher::SlackAlertDispatcher(
+            AlertDispatchType::Slack => AlertDispatcher::Slack(
                 HttpAlertDispatcher::new(SlackAlerter::default()),
             ),
             AlertDispatchType::Email => panic!("Unsupported dispatcher type: Email"),

--- a/src/alerts/drift.rs
+++ b/src/alerts/drift.rs
@@ -101,7 +101,7 @@ impl DriftExecutor {
                         "error converting postgres jsonb profile to struct type DriftProfile"
                     })?;
                 let next_run: NaiveDateTime = profile.get("next_run");
-                let cron: String = profile.get("cron");
+                let schedule: String = profile.get("schedule");
                 // Compute drift
                 let drift_array = self
                     .compute_drift(&drift_profile, &next_run)
@@ -122,7 +122,11 @@ impl DriftExecutor {
 
                 // Process alerts
                 self.alert_dispatcher
-                    .process_alerts(&alerts, &drift_profile.config.name)
+                    .process_alerts(
+                        &alerts,
+                        &drift_profile.config.repository,
+                        &drift_profile.config.name,
+                    )
                     .await?;
 
                 // Update run dates for profile
@@ -131,7 +135,7 @@ impl DriftExecutor {
                     &drift_profile.config.name,
                     &drift_profile.config.repository,
                     &drift_profile.config.version,
-                    &cron,
+                    &schedule,
                 )
                 .await?;
             } else {

--- a/src/alerts/drift.rs
+++ b/src/alerts/drift.rs
@@ -7,7 +7,7 @@ use scouter::utils::types::{AlertDispatchType, DriftProfile};
 
 use anyhow::{Context, Result};
 
-use crate::alerts::dispatch::{AlertDispatcher, ConsoleAlertDispatcher, OpsGenieAlertDispatcher};
+use crate::alerts::dispatch::{AlertDispatcher, ConsoleAlertDispatcher, OpsGenieAlertDispatcher, SlackAlertDispatcher};
 use ndarray::Array2;
 use sqlx::{Postgres, Row};
 use tracing::info;
@@ -80,7 +80,7 @@ impl DriftExecutor {
             AlertDispatchType::OpsGenie => {
                 AlertDispatcher::OpsGenie(OpsGenieAlertDispatcher::default())
             }
-            AlertDispatchType::Slack => panic!("Unsupported dispatcher type: Slack"),
+            AlertDispatchType::Slack => AlertDispatcher::Slack(SlackAlertDispatcher::default()),
             AlertDispatchType::Email => panic!("Unsupported dispatcher type: Email"),
         }
     }

--- a/src/alerts/drift.rs
+++ b/src/alerts/drift.rs
@@ -78,12 +78,12 @@ impl DriftExecutor {
     fn map_dispatcher(dispatch_type: &AlertDispatchType) -> AlertDispatcher {
         match dispatch_type {
             AlertDispatchType::Console => AlertDispatcher::Console(ConsoleAlertDispatcher),
-            AlertDispatchType::OpsGenie => AlertDispatcher::OpsGenie(
-                HttpAlertDispatcher::new(OpsGenieAlerter::default()),
-            ),
-            AlertDispatchType::Slack => AlertDispatcher::Slack(
-                HttpAlertDispatcher::new(SlackAlerter::default()),
-            ),
+            AlertDispatchType::OpsGenie => {
+                AlertDispatcher::OpsGenie(HttpAlertDispatcher::new(OpsGenieAlerter::default()))
+            }
+            AlertDispatchType::Slack => {
+                AlertDispatcher::Slack(HttpAlertDispatcher::new(SlackAlerter::default()))
+            }
             AlertDispatchType::Email => panic!("Unsupported dispatcher type: Email"),
         }
     }

--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -120,7 +120,7 @@ pub struct InsertDriftProfileParams {
     pub repository: String,
     pub version: String,
     pub profile: String,
-    pub cron: String,
+    pub schedule: String,
     pub next_run: NaiveDateTime,
 }
 
@@ -132,7 +132,7 @@ impl ToMap for InsertDriftProfileParams {
         params.insert("repository".to_string(), self.repository.clone());
         params.insert("version".to_string(), self.version.clone());
         params.insert("profile".to_string(), self.profile.clone());
-        params.insert("cron".to_string(), self.cron.clone());
+        params.insert("schedule".to_string(), self.schedule.clone());
         params.insert("next_run".to_string(), self.next_run.to_string());
 
         params
@@ -281,7 +281,7 @@ WHERE
 
         assert_eq!(
             formatted_sql,
-            "SELECT profile, next_run, cron\nFROM schema.table\nWHERE active\n  AND next_run < CURRENT_TIMESTAMP\nLIMIT 1 FOR UPDATE SKIP LOCKED;"
+            "SELECT profile, next_run, schedule\nFROM schema.table\nWHERE active\n  AND next_run < CURRENT_TIMESTAMP\nLIMIT 1 FOR UPDATE SKIP LOCKED;"
         );
     }
 

--- a/src/sql/scripts/get_drift_profile.sql
+++ b/src/sql/scripts/get_drift_profile.sql
@@ -1,4 +1,4 @@
-SELECT profile, next_run, cron
+SELECT profile, next_run, schedule
 FROM $table
 WHERE active
   AND next_run < CURRENT_TIMESTAMP

--- a/src/sql/scripts/insert_drift_profile.sql
+++ b/src/sql/scripts/insert_drift_profile.sql
@@ -1,3 +1,3 @@
-INSERT INTO $table (name, repository, version, profile, cron, next_run) 
-VALUES ('$name', '$repository', '$version', '$profile', '$cron', '$next_run')
+INSERT INTO $table (name, repository, version, profile, schedule, next_run)
+VALUES ('$name', '$repository', '$version', '$profile', '$schedule', '$next_run')
 ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Pull Request

### Short Summary
Adds Slack dispatcher

### Context
While adding the slack dispatcher, I decided to redesign the dispatcher src code to utilize a generic HTTP dispatcher, which can use N number of alerter types such as Slack, Opsgenie, etc.

### Is this a Breaking Change?
No breaking changes